### PR TITLE
3 featconfig global logging config

### DIFF
--- a/taskflow/backend/config/logger.py
+++ b/taskflow/backend/config/logger.py
@@ -1,1 +1,63 @@
 # TODO: Implement logging configuration
+import logging
+import logging.config
+import os
+from pathlib import Path
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+LOG_DIR = os.getenv("LOG_DIR", "logs")
+LOG_FILE = os.getenv("LOG_FILE", "taskflow.log")
+LOG_PATH = Path(LOG_DIR)
+LOG_PATH.mkdir(exist_ok=True)
+
+LOGGING_CONFIG = {
+	"version": 1,
+	"disable_existing_loggers": False,
+	"formatters": {
+		"standard": {
+			"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+		},
+		"detailed": {
+			"format": "%(asctime)s [%(levelname)s] %(name)s (%(filename)s:%(lineno)d): %(message)s"
+		}
+	},
+	"handlers": {
+		"console": {
+			"class": "logging.StreamHandler",
+			"formatter": "standard",
+			"level": LOG_LEVEL,
+			"stream": "ext://sys.stdout"
+		},
+		"file": {
+			"class": "logging.handlers.RotatingFileHandler",
+			"formatter": "detailed",
+			"level": LOG_LEVEL,
+			"filename": str(LOG_PATH / LOG_FILE),
+			"maxBytes": 5 * 1024 * 1024,  # 5MB
+			"backupCount": 5,
+			"encoding": "utf8"
+		}
+	},
+	"root": {
+		"level": LOG_LEVEL,
+		"handlers": ["console", "file"]
+	},
+	"loggers": {
+		"uvicorn": {
+			"level": "WARNING",
+			"handlers": ["console", "file"],
+			"propagate": False
+		},
+		"taskflow": {
+			"level": LOG_LEVEL,
+			"handlers": ["console", "file"],
+			"propagate": False
+		}
+	}
+}
+
+def setup_logging():
+	logging.config.dictConfig(LOGGING_CONFIG)
+
+def get_logger(name: str = "taskflow") -> logging.Logger:
+	return logging.getLogger(name)

--- a/taskflow/backend/extractor/service.py
+++ b/taskflow/backend/extractor/service.py
@@ -3,19 +3,17 @@ AI Task Extractor Service - Subscribes to messages and extracts tasks.
 For MVP, uses simple rule-based extraction. Can be enhanced with LLM integration later.
 """
 
-import logging
-import uuid
+from taskflow.backend.config.logger import setup_logging, get_logger
 from typing import List
 
 from taskflow.backend.config.settings import config
 from taskflow.backend.utils.messaging import MessageBroker, setup_taskflow_infrastructure
-from taskflow.models.extractor import LLMResponse, RawTask, Task
+from taskflow.models.extractor import LLMResponse, Task
 from taskflow.shared.events import MessageReceived, TaskExtracted
 from taskflow.backend.utils.prompts import build_extraction_prompt_with_few_shots
 from taskflow.backend.utils.llms import get_llm
-import json
 
-logger = logging.getLogger(__name__)
+logger = get_logger("taskflow.backend.extractor")
 
 
 class TaskExtractor:
@@ -136,10 +134,8 @@ def create_extractor_service() -> ExtractorService:
 
 def run_extractor_service():
     """Run the extractor service."""
-    logging.basicConfig(level=getattr(logging, config.log_level))
-    
+    setup_logging()
     service = create_extractor_service()
-    
     try:
         service.start_consuming()
     except KeyboardInterrupt:

--- a/taskflow/backend/ingestor/service.py
+++ b/taskflow/backend/ingestor/service.py
@@ -3,7 +3,7 @@ Ingestor Service - Accepts messages and publishes conversation.message_received 
 For MVP, this provides a simple interface to submit messages manually.
 """
 
-import logging
+from taskflow.backend.config.logger import setup_logging, get_logger
 import uuid
 from datetime import datetime
 from typing import Optional
@@ -12,7 +12,7 @@ from taskflow.backend.config.settings import config
 from taskflow.backend.utils.messaging import MessageBroker, setup_taskflow_infrastructure
 from taskflow.shared.events import MessageReceived
 
-logger = logging.getLogger(__name__)
+logger = get_logger("taskflow.backend.ingestor")
 
 
 class IngestorService:
@@ -128,27 +128,20 @@ def run_ingestor_cli():
     Run the ingestor service in CLI mode for testing.
     Allows manual message input for demonstration purposes.
     """
-    logging.basicConfig(level=getattr(logging, config.log_level))
-    
+    setup_logging()
     print("🚀 Starting Taskflow Ingestor Service (CLI Mode)")
     print("Type messages to ingest them. Type 'quit' to exit.\n")
-    
     service = create_ingestor_service()
-    
     try:
         while True:
             # Get user input
             content = input("Message content: ").strip()
-            
             if content.lower() == 'quit':
                 break
-                
             if not content:
                 continue
-            
             author = input("Author (default: user): ").strip() or "user"
             channel = input("Channel (optional): ").strip() or None
-            
             try:
                 message_id = service.ingest_message(
                     content=content,
@@ -156,15 +149,11 @@ def run_ingestor_cli():
                     source="cli",
                     channel=channel
                 )
-                
                 print(f"✅ Ingested message: {message_id}\n")
-                
             except Exception as e:
                 print(f"❌ Error ingesting message: {e}\n")
-    
     except KeyboardInterrupt:
         print("\n👋 Shutting down ingestor service...")
-    
     finally:
         service.broker.disconnect()
 

--- a/taskflow/backend/platform_manager/service.py
+++ b/taskflow/backend/platform_manager/service.py
@@ -3,7 +3,7 @@ Platform Manager Service - Subscribes to extracted tasks and manages task creati
 For MVP, simulates task creation by logging to console and storing in memory.
 """
 
-import logging
+from taskflow.backend.config.logger import setup_logging, get_logger
 import uuid
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -13,7 +13,7 @@ from taskflow.backend.config.settings import config
 from taskflow.backend.utils.messaging import MessageBroker, setup_taskflow_infrastructure
 from taskflow.shared.events import TaskExtracted, TaskCreated, TaskFailed
 
-logger = logging.getLogger(__name__)
+logger = get_logger("taskflow.backend.platform_manager")
 
 
 class MockPlatform:
@@ -231,10 +231,8 @@ def create_platform_manager_service() -> PlatformManagerService:
 
 def run_platform_manager_service():
     """Run the platform manager service."""
-    logging.basicConfig(level=getattr(logging, config.log_level))
-    
+    setup_logging()
     service = create_platform_manager_service()
-    
     try:
         service.start_consuming()
     except KeyboardInterrupt:


### PR DESCRIPTION
This pull request introduces a centralized logging configuration for the backend services in the Taskflow project, replacing ad-hoc logging setups with a consistent, configurable approach. The main changes include adding a new logger module, updating service files to use the centralized logger, and ensuring logging is initialized properly in service startup routines.

**Centralized Logging Configuration**

* Added a new module `taskflow/backend/config/logger.py` that defines a reusable logging setup using environment variables, rotating file handlers, and custom formatters, along with utility functions `setup_logging` and `get_logger`.

**Service File Refactoring**

* Updated imports in `extractor/service.py`, `ingestor/service.py`, and `platform_manager/service.py` to use `setup_logging` and `get_logger` from the new logger module, replacing direct `logging` imports. [[1]](diffhunk://#diff-926007c61ed39e3bee873d7d0701b1a2768431d52e9720dd71174fbdb5d56393L6-R16) [[2]](diffhunk://#diff-fffda75ea58a2908ee53d0d92f3415c346fe828b44b0e784d43eba61837a184bL6-R6) [[3]](diffhunk://#diff-c1a8ccac5d42dd04695ee884dfef03a2e1600275921233804e63375db05e503bL6-R6)
* Changed logger initialization in these services to use descriptive logger names, improving log traceability. [[1]](diffhunk://#diff-926007c61ed39e3bee873d7d0701b1a2768431d52e9720dd71174fbdb5d56393L6-R16) [[2]](diffhunk://#diff-fffda75ea58a2908ee53d0d92f3415c346fe828b44b0e784d43eba61837a184bL15-R15) [[3]](diffhunk://#diff-c1a8ccac5d42dd04695ee884dfef03a2e1600275921233804e63375db05e503bL16-R16)

**Service Startup Improvements**

* Replaced previous `logging.basicConfig` calls in service startup functions with calls to `setup_logging`, ensuring the new logging configuration is applied consistently across all services. [[1]](diffhunk://#diff-926007c61ed39e3bee873d7d0701b1a2768431d52e9720dd71174fbdb5d56393L139-L142) [[2]](diffhunk://#diff-fffda75ea58a2908ee53d0d92f3415c346fe828b44b0e784d43eba61837a184bL131-L167) [[3]](diffhunk://#diff-c1a8ccac5d42dd04695ee884dfef03a2e1600275921233804e63375db05e503bL234-L237)